### PR TITLE
Allows for listings to provide the escrow release type 

### DIFF
--- a/src/buyflow/madct.ts
+++ b/src/buyflow/madct.ts
@@ -6,6 +6,7 @@ import { IMadCTBuilder } from '../abstract/transactions';
 import { Config } from '../abstract/config';
 import { buildBidTxScript, buildDestroyTxScript, ConfidentialTransactionBuilder, getExpectedSequence } from '../transaction-builder/confidential-transaction';
 import { MPA_ACCEPT, MPA_BID, MPA_LISTING_ADD, MPA_LOCK, PaymentDataAcceptCT, PaymentDataBidCT, PaymentDataLockCT } from '../interfaces/omp';
+import { EscrowReleaseType } from '../interfaces/omp-enums';
 import { asyncMap, clone, isArrayAndContains, isObject } from '../util';
 import { hash } from '../hasher/hash';
 
@@ -273,20 +274,23 @@ export class MadCTBuilder implements IMadCTBuilder {
         const buyer_blindFactor_release = isSellerLastOutput ? bidPaymentData.release.blindFactor : lastBlindFactor;
         const seller_blindFactor_release = isSellerLastOutput ?  lastBlindFactor : acceptPaymentData.release.blindFactor!;
 
+        const releaseType = listing.item.payment.escrow && listing.item.payment.escrow.releaseType ?
+            listing.item.payment.escrow.releaseType : EscrowReleaseType.BLIND;
+
         // Randomize the positioning for increased privacy.
         // based on whether the buyer provided a blind factor or not.
         const buyer_releaseSatoshis = this.release_calculateRequiredSatoshis(listing, bid, false);
         const seller_releaseSatoshis = this.release_calculateRequiredSatoshis(listing, bid, true);
         const release_outputs: ToBeBlindOutput[] = [
-            this.getReleaseOutput(buyer_release_address, buyer_releaseSatoshis, buyer_blindFactor_release), // buyer_release_output
-            this.getReleaseOutput(seller_release_address, seller_releaseSatoshis - seller_fee, seller_blindFactor_release) // seller_release_output
+            this.getReleaseOutput(buyer_release_address, buyer_releaseSatoshis, buyer_blindFactor_release, releaseType), // buyer_release_output
+            this.getReleaseOutput(seller_release_address, seller_releaseSatoshis - seller_fee, seller_blindFactor_release, releaseType) // seller_release_output
         ];
 
         const buyer_refundSatoshis = this.release_calculateRequiredSatoshis(listing, bid, false, true);
         const seller_refundSatoshis = this.release_calculateRequiredSatoshis(listing, bid, true, true);
         const refund_outputs: ToBeBlindOutput[] = [
-            this.getReleaseOutput(buyer_release_address, buyer_refundSatoshis, buyer_blindFactor_release), // buyer_refund_output
-            this.getReleaseOutput(seller_release_address, seller_refundSatoshis - seller_fee, seller_blindFactor_release) // seller_refund_output
+            this.getReleaseOutput(buyer_release_address, buyer_refundSatoshis, buyer_blindFactor_release, releaseType), // buyer_refund_output
+            this.getReleaseOutput(seller_release_address, seller_refundSatoshis - seller_fee, seller_blindFactor_release, releaseType) // seller_refund_output
         ];
 
         // If seller is not the last output, swap them.
@@ -645,13 +649,13 @@ export class MadCTBuilder implements IMadCTBuilder {
         }];
     }
 
-    private getReleaseOutput(address: CryptoAddress, satoshis: number, blind: string): ToBeBlindOutput {
+    private getReleaseOutput(address: CryptoAddress, satoshis: number, blind: string, releaseType: EscrowReleaseType): ToBeBlindOutput {
 
         // for now, we are forcing anon
         // const type = (this.network === 'testnet') ? 'anon' : 'blind';
         return {
             address,
-            _type: 'anon',
+            _type: releaseType,
             _satoshis: satoshis,
             blindFactor: blind
         };

--- a/src/interfaces/omp-enums.ts
+++ b/src/interfaces/omp-enums.ts
@@ -36,6 +36,11 @@ export enum EscrowType {
     MAD_CT = 'MAD_CT'           // Mutual assured destruction with Confidential Tx
 }
 
+export enum EscrowReleaseType {
+    BLIND = 'blind',
+    ANON = 'anon'
+}
+
 /**
  * Protocols supported by the protocol.
  */

--- a/src/interfaces/omp.ts
+++ b/src/interfaces/omp.ts
@@ -6,7 +6,7 @@
 
 import { Prevout, CryptoAddress, Cryptocurrency, ISignature, ToBeOutput, EphemeralKey, Fiatcurrency, ToBeBlindOutput, BlindPrevout } from './crypto';
 import { DSN, ContentReference } from './dsn';
-import { MPAction, SaleType, EscrowType, MessagingProtocol } from './omp-enums';
+import { MPAction, SaleType, EscrowType, EscrowReleaseType, MessagingProtocol } from './omp-enums';
 import { KVS } from './common';
 
 
@@ -331,6 +331,7 @@ export interface EscrowConfig {
     type: EscrowType;
     ratio: EscrowRatio;
     secondsToLock: number;
+    releaseType?: EscrowReleaseType;
 }
 
 /**


### PR DESCRIPTION
The escrow on a listing item, if provided, can specify whether to release an escrow to blind or anon type. Defaults to blind if not specified/provided.