### PR TITLE
Fix error handling

### DIFF
--- a/src/abstract/rpc.ts
+++ b/src/abstract/rpc.ts
@@ -292,7 +292,12 @@ export abstract class CtRpc extends Rpc {
             blindingfactor = this.getRandomBlindFactor();
         }
 
-        const txid = await this.sendTypeTo(wallet, typeFrom, typeTo, [{ address: sx.address, amount, blindingfactor}]).catch(() => '');
+        const txid = await this.sendTypeTo(wallet, typeFrom, typeTo, [{ address: sx.address, amount, blindingfactor}]).catch(err => {
+            if (err) {
+                throw err;
+            }
+            return '';
+        });
         if (!txid) {
             throw new Error('Send failed!');
         }


### PR DESCRIPTION
When the implementation of the abstract `sendTypeTo()` call errors within `createPrevoutsFrom() `, the resulting error is inadvertently changed and re-thrown, leaving the caller implementation no way to determine what the source of the error was (in case it needs to provide some specific corrective measure). 

This change simply rethrows the caught error if it exists, instead of handling it and then throwing the generic error afterwards. 